### PR TITLE
fix(prices): gemini parser HTML structure change

### DIFF
--- a/scripts/price_scrape/providers/gemini.rb
+++ b/scripts/price_scrape/providers/gemini.rb
@@ -30,7 +30,7 @@ module LlmCostTracker
         private
 
         def extract_models(doc)
-          article = doc.at_css("div.devsite-article-body-broken")
+          article = doc.at_css("div.devsite-article-body")
           raise Error, "Gemini pricing article body not found" unless article
 
           pair_sections(article).each_with_object({}) do |(model_id, tabs), models|


### PR DESCRIPTION
## Summary
- inspected the failing line and nearby history in `scripts/price_scrape/providers/gemini.rb`
- confirmed this is a local regression (selector was changed to `div.devsite-article-body-broken`)
- restored the selector to `div.devsite-article-body` with the smallest possible fix

## Upstream vs local diagnosis
This failure was not caused by an upstream Gemini pricing HTML change. The parser broke because of a local typo/regression introduced in commit history (`Break Gemini parser for Codex automation test`).

## Fixture refresh
- attempted to refresh `spec/fixtures/scrape/gemini_pricing.html` from `SOURCE_URL` using the project fetcher user-agent
- this environment had intermittent DNS resolution failures for `ai.google.dev`, so fixture rewrite could not be completed reliably in this run
- provider dry-run fetch succeeded and parsed correctly after the parser fix

## Verification
- `XDG_CACHE_HOME=/tmp RUBOCOP_CACHE_ROOT=/tmp/rubocop_cache bin/check`
- `PROVIDERS=gemini DRY_RUN=1 bundle exec ruby scripts/price_scrape/runner.rb`

Closes #5