### PR TITLE
feat: gemini-ai SDK integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ## [Unreleased]
 
+### Added
+
+- `gemini-ai` SDK integration (`:gemini_ai`): `generate_content` and `stream_generate_content` calls are now automatically captured, including SSE streaming calls. Instrument with `config.instrument :gemini_ai`. Requires `gemini-ai >= 4.0.0`.
+
 ### Removed
 
 - BREAKING: the experimental `Reconciliation` subsystem (provider invoice import + diff, the `/reconciliation` dashboard page, `bin/rails llm_cost_tracker:reconcile:*` rake tasks, `config.reconciliation_enabled`, `config.reconciliation_importers`, the `llm_cost_tracker:reconciliation` generator, and the `llm_cost_tracker_provider_invoices` / `_provider_invoice_imports` tables) is gone. It was never finished and never billing-accurate. `calls.provider_response_id` (captured on every call) already covers invoice cross-reference; if invoice-vs-ledger reconciliation ships again it lives in a separate gem. Existing installs can drop the two tables — see [docs/upgrading.md](docs/upgrading.md#v011--v012-unreleased).

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The engine ships without authentication on purpose.
 | OpenAI | Official SDK or Faraday |
 | Anthropic | Official SDK or Faraday |
 | Azure OpenAI | Faraday or official SDK (auto-detected on `*.openai.azure.com` and Foundry `*.services.ai.azure.com`, both deployments and `/openai/v1/...`) |
-| Google Gemini | Faraday |
+| Google Gemini | `gemini-ai` SDK or Faraday |
 | RubyLLM | Provider layer |
 | `ruby-openai` | Faraday |
 | OpenRouter, DeepSeek, Groq, LiteLLM-style gateways | OpenAI-compatible Faraday |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,6 +54,7 @@ Built-in integration names:
 | --- | --- | --- |
 | `:openai` | `openai >= 0.59.0` | Responses, Chat Completions, streaming helpers |
 | `:anthropic` | `anthropic >= 1.36.0` | Messages and beta Messages helpers |
+| `:gemini_ai` | `gemini-ai >= 4.0.0` | `generate_content` and `stream_generate_content`, including SSE streaming |
 | `:ruby_llm` | `ruby_llm >= 1.15.0` | Provider chat, embedding, transcription, image, and moderation calls |
 
 ## OpenAI-Compatible Hosts

--- a/lib/llm_cost_tracker/integrations.rb
+++ b/lib/llm_cost_tracker/integrations.rb
@@ -8,9 +8,11 @@ module LlmCostTracker
     autoload :Openai, "llm_cost_tracker/integrations/openai"
     autoload :Anthropic, "llm_cost_tracker/integrations/anthropic"
     autoload :RubyLlm, "llm_cost_tracker/integrations/ruby_llm"
+    autoload :GeminiAi, "llm_cost_tracker/integrations/gemini_ai"
 
-    INTEGRATION_CONSTANTS = { openai: :Openai, anthropic: :Anthropic, ruby_llm: :RubyLlm }.freeze
-    DOUBLE_INSTRUMENTATION_OVERLAPS = %i[openai anthropic].freeze
+    INTEGRATION_CONSTANTS = { openai: :Openai, anthropic: :Anthropic, ruby_llm: :RubyLlm,
+                               gemini_ai: :GeminiAi }.freeze
+    DOUBLE_INSTRUMENTATION_OVERLAPS = %i[openai anthropic gemini_ai].freeze
     private_constant :DOUBLE_INSTRUMENTATION_OVERLAPS
     def self.install!(names = LlmCostTracker.configuration.instrumented_integrations)
       normalized = normalize(names)

--- a/lib/llm_cost_tracker/integrations/gemini_ai.rb
+++ b/lib/llm_cost_tracker/integrations/gemini_ai.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+module LlmCostTracker
+  module Integrations
+    module GeminiAi
+      extend Base
+
+      class << self
+        def integration_name
+          :gemini_ai
+        end
+
+        def enforce_budget!(request:)
+          return unless active?
+
+          LlmCostTracker::Budget.enforce!(
+            provider: "gemini",
+            model: request[:model],
+            request: request
+          )
+        end
+
+        def minimum_version
+          "4.0.0"
+        end
+
+        # gemini-ai exposes Gemini::GEM[:version], not Gemini::VERSION,
+        # so base.rb's default constant_version can't find it.
+        def constant_version
+          gem_hash = "Gemini::GEM".safe_constantize
+          return nil unless gem_hash.is_a?(Hash)
+
+          Gem::Version.new(gem_hash[:version].to_s)
+        rescue ArgumentError
+          nil
+        end
+
+        def patch_targets
+          [patch_target("Gemini::Controllers::Client", with: ClientPatch)]
+        end
+
+        def record_response(response, path:, payload:, base_address:, latency_ms:)
+          return unless active?
+          return unless response.is_a?(Hash)
+
+          record_safely do
+            url = "#{base_address}/#{path}"
+            event = LlmCostTracker::Parsers.find_for_provider("gemini")&.parse(
+              request_url: url,
+              request_body: payload&.to_json,
+              response_status: 200,
+              response_body: response.to_json
+            )
+            next unless event
+
+            LlmCostTracker::Tracker.record(event: event, latency_ms: latency_ms)
+          end
+        end
+
+        def record_stream_response(stream_events, path:, payload:, base_address:, latency_ms:)
+          return unless active?
+          return unless stream_events.is_a?(Array)
+
+          record_safely do
+            url = "#{base_address}/#{path}"
+            # stream_events is an array of parsed JSON hashes (the :event field from each SSE chunk).
+            # Wrap them in the {data: hash} shape that parse_stream / find_event_value expects.
+            events = stream_events.map { |chunk| { data: chunk } }
+            event = LlmCostTracker::Parsers.find_for_provider("gemini")&.parse_stream(
+              request_url: url,
+              request_body: payload&.to_json,
+              response_status: 200,
+              events: events
+            )
+            next unless event
+
+            LlmCostTracker::Tracker.record(event: event, latency_ms: latency_ms)
+          end
+        end
+      end
+
+      module ClientPatch
+        def request(path, payload, server_sent_events: nil, request_method: "POST", &callback)
+          addr = @model_address.to_s
+          bare_model = addr.include?("/models/") ? addr.split("/models/").last : nil
+          request_hash = (payload || {}).merge(model: bare_model)
+          LlmCostTracker::Integrations::GeminiAi.enforce_budget!(request: request_hash)
+
+          sse = server_sent_events.nil? ? @server_sent_events : server_sent_events
+
+          # For non-SSE generateContent calls, record the blocking response.
+          if path.to_s.end_with?(":generateContent") && !sse
+            started_at = LlmCostTracker::Timing.now_monotonic
+            response = super
+
+            LlmCostTracker::Integrations::GeminiAi.record_response(
+              response,
+              path: path,
+              payload: payload,
+              base_address: @base_address,
+              latency_ms: LlmCostTracker::Timing.elapsed_ms(started_at)
+            )
+
+            return response
+          end
+
+          # For SSE calls (generateContent or streamGenerateContent), the gem collects
+          # all chunks synchronously and returns an array of parsed event hashes.
+          # Record usage from the accumulated stream after super returns.
+          if sse
+            started_at = LlmCostTracker::Timing.now_monotonic
+            stream_events = super
+
+            LlmCostTracker::Integrations::GeminiAi.record_stream_response(
+              stream_events,
+              path: path,
+              payload: payload,
+              base_address: @base_address,
+              latency_ms: LlmCostTracker::Timing.elapsed_ms(started_at)
+            )
+
+            return stream_events
+          end
+
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/llm_cost_tracker/providers/gemini/parser.rb
+++ b/lib/llm_cost_tracker/providers/gemini/parser.rb
@@ -35,6 +35,7 @@ module LlmCostTracker
           model = extract_model_from_url(request_url)
           build_event(
             request_url: request_url,
+            model_version: response["modelVersion"],
             usage: usage,
             usage_source: "response",
             provider_response_id: response["responseId"],
@@ -56,6 +57,7 @@ module LlmCostTracker
           if usage
             build_event(
               request_url: request_url,
+              model_version: stream_model_version(events),
               usage: usage,
               stream: true,
               usage_source: "stream_final",
@@ -84,16 +86,18 @@ module LlmCostTracker
 
         private
 
-        def build_event(request_url:, usage:, usage_source:, stream: false, provider_response_id: nil,
-                        pricing_mode: nil, service_line_items: nil)
+        def build_event(request_url:, usage:, usage_source:, model_version: nil, stream: false,
+                        provider_response_id: nil, pricing_mode: nil, service_line_items: nil)
           cache_read = usage["cachedContentTokenCount"].to_i
           tool_use_prompt = usage["toolUsePromptTokenCount"].to_i
           audio_input = audio_input_tokens(usage)
           audio_output = audio_output_tokens(usage)
 
+          resolved_model = model_version.to_s.strip.presence || extract_model_from_url(request_url)
+
           Event.build(
             provider: "gemini",
-            model: extract_model_from_url(request_url),
+            model: resolved_model,
             pricing_mode: pricing_mode,
             token_usage: TokenUsage.build(
               input_tokens: regular_input_tokens(usage: usage, cache_read: cache_read, audio_input: audio_input) +
@@ -151,6 +155,10 @@ module LlmCostTracker
 
         def stream_response_id(events)
           find_event_value(events) { |data| data["responseId"] }
+        end
+
+        def stream_model_version(events)
+          find_event_value(events, reverse: true) { |data| data["modelVersion"].presence }
         end
 
         def extract_model_from_url(url)

--- a/llm_cost_tracker.gemspec
+++ b/llm_cost_tracker.gemspec
@@ -42,6 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "railties", ">= 7.1", "< 9.0"
 
   spec.add_development_dependency "anthropic", "~> 1.42"
+  spec.add_development_dependency "gemini-ai", "~> 4.3"
   spec.add_development_dependency "nokogiri", "~> 1.16"
   spec.add_development_dependency "openai", "~> 0.63"
   spec.add_development_dependency "pg", "~> 1.6"

--- a/spec/fixtures/sdk_responses/gemini/generate_content_basic.json
+++ b/spec/fixtures/sdk_responses/gemini/generate_content_basic.json
@@ -1,0 +1,23 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "Hello! How can I help you today?"
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 10,
+    "candidatesTokenCount": 9,
+    "totalTokenCount": 19
+  },
+  "responseId": "gemini-sdk-resp-001",
+  "modelVersion": "gemini-2.5-flash-preview-05-20"
+}

--- a/spec/llm_cost_tracker/integrations/gemini_ai_spec.rb
+++ b/spec/llm_cost_tracker/integrations/gemini_ai_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "gemini-ai"
+
+RSpec.describe LlmCostTracker::Integrations::GeminiAi do
+  before { configure_sdk_integration(:gemini_ai) }
+
+  let(:client) do
+    Gemini.new(
+      credentials: {
+        service: "generative-language-api",
+        api_key: "test-key"
+      },
+      options: { model: "gemini-2.5-flash" }
+    )
+  end
+
+  let(:generate_content_url_pattern) do
+    %r{https://generativelanguage\.googleapis\.com/v1/models/gemini-2\.5-flash:generateContent}
+  end
+
+  let(:request_params) do
+    { contents: [{ role: "user", parts: [{ text: "Hello" }] }] }
+  end
+
+  describe "generate_content (blocking)" do
+    it "records token usage from a real SDK response shape" do
+      stub_sdk_json(
+        :post, generate_content_url_pattern,
+        provider: :gemini, fixture: "generate_content_basic.json"
+      )
+
+      capture_sdk_events do |events|
+        response = client.generate_content(request_params)
+
+        expect(response).to be_a(Hash)
+        expect(events.size).to eq(1)
+        expect(events.first).to include(
+          provider: "gemini",
+          model: "gemini-2.5-flash-preview-05-20",
+          input_tokens: 10,
+          output_tokens: 9,
+          usage_source: "response",
+          provider_response_id: "gemini-sdk-resp-001"
+        )
+      end
+    end
+
+    it "does not record when the upstream call raises" do
+      WebMock.stub_request(:post, generate_content_url_pattern).to_return(
+        status: 429,
+        body: { error: { message: "Resource exhausted", code: 429 } }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+
+      capture_sdk_events do |events|
+        expect { client.generate_content(request_params) }.to raise_error(Faraday::ClientError)
+        expect(events).to be_empty
+      end
+    end
+  end
+
+  describe "generate_content (SSE / streaming)" do
+    let(:sse_url_pattern) do
+      %r{https://generativelanguage\.googleapis\.com/v1/models/gemini-2\.5-flash:generateContent\?alt=sse}
+    end
+
+    let(:sse_body) do
+      <<~SSE
+        data: {"candidates":[{"content":{"parts":[{"text":"Hello"}],"role":"model"},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":9,"totalTokenCount":19},"responseId":"gemini-stream-001"}
+
+      SSE
+    end
+
+    it "records token usage from an SSE streaming call" do
+      stub_sdk_sse(:post, sse_url_pattern, body: sse_body)
+
+      capture_sdk_events do |events|
+        client.generate_content(request_params, server_sent_events: true) do |_event, _parsed, _raw|
+          nil
+        end
+
+        expect(events.size).to eq(1)
+        expect(events.first).to include(
+          provider: "gemini",
+          model: "gemini-2.5-flash",
+          input_tokens: 10,
+          output_tokens: 9
+        )
+      end
+    end
+
+    it "does not record when the upstream SSE call raises" do
+      WebMock.stub_request(:post, sse_url_pattern).to_return(
+        status: 429,
+        body: { error: { message: "Resource exhausted", code: 429 } }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+
+      capture_sdk_events do |events|
+        expect do
+          client.generate_content(request_params, server_sent_events: true) do |_event, _parsed, _raw|
+            nil
+          end
+        end.to raise_error(Faraday::ClientError)
+        expect(events).to be_empty
+      end
+    end
+  end
+end

--- a/spec/llm_cost_tracker/integrations/install_contract_spec.rb
+++ b/spec/llm_cost_tracker/integrations/install_contract_spec.rb
@@ -2,6 +2,7 @@
 
 require "spec_helper"
 require "anthropic"
+require "gemini-ai"
 require "openai"
 require "ruby_llm"
 
@@ -65,7 +66,7 @@ RSpec.describe LlmCostTracker::Integrations do
 
   it "expands the all instrumentation alias" do
     LlmCostTracker.configure { |c| c.instrument(:all) }
-    expect(LlmCostTracker.configuration.instrumented_integrations).to contain_exactly(:openai, :anthropic, :ruby_llm)
+    expect(LlmCostTracker.configuration.instrumented_integrations).to contain_exactly(:openai, :anthropic, :ruby_llm, :gemini_ai)
     expect { LlmCostTracker.configuration.instrumented_integrations.add(:gemini) }.to raise_error(FrozenError)
   end
 

--- a/spec/llm_cost_tracker/providers/gemini/parser_spec.rb
+++ b/spec/llm_cost_tracker/providers/gemini/parser_spec.rb
@@ -167,6 +167,46 @@ RSpec.describe LlmCostTracker::Providers::Gemini::Parser do
       expect(result.token_usage.total_tokens).to eq(170)
     end
 
+    it "prefers modelVersion from the response body over the request URL model alias" do
+      alias_url = URI::HTTPS.build(
+        host: "generativelanguage.googleapis.com",
+        path: "/v1beta/models/gemini-2.5-flash-latest:generateContent"
+      ).to_s
+
+      result = parser.parse(
+        request_url: alias_url,
+        request_body: nil,
+        response_status: 200,
+        response_body: {
+          modelVersion: "gemini-2.5-flash-001",
+          usageMetadata: {
+            promptTokenCount: 50,
+            candidatesTokenCount: 10,
+            totalTokenCount: 60
+          }
+        }.to_json
+      )
+
+      expect(result.model).to eq("gemini-2.5-flash-001")
+    end
+
+    it "falls back to the URL model when modelVersion is absent" do
+      result = parser.parse(
+        request_url: generate_content_url,
+        request_body: nil,
+        response_status: 200,
+        response_body: {
+          usageMetadata: {
+            promptTokenCount: 50,
+            candidatesTokenCount: 10,
+            totalTokenCount: 60
+          }
+        }.to_json
+      )
+
+      expect(result.model).to eq("gemini-2.5-flash")
+    end
+
     it "captures Flex pricing from the request body" do
       result = parser.parse(
         request_url: generate_content_url,
@@ -287,6 +327,32 @@ RSpec.describe LlmCostTracker::Providers::Gemini::Parser do
 
   describe "#parse_stream" do
     let(:url) { stream_generate_content_url }
+
+    it "prefers modelVersion from the last stream chunk over the request URL model alias" do
+      alias_url = URI::HTTPS.build(
+        host: "generativelanguage.googleapis.com",
+        path: "/v1beta/models/gemini-2.5-flash-latest:streamGenerateContent"
+      ).to_s
+
+      events = [
+        { event: nil, data: {
+          "modelVersion" => "gemini-2.5-flash-001",
+          "usageMetadata" => {
+            "promptTokenCount" => 80,
+            "candidatesTokenCount" => 20,
+            "totalTokenCount" => 100
+          }
+        } }
+      ]
+
+      result = parser.parse_stream(
+        request_url: alias_url,
+        response_status: 200,
+        events: events
+      )
+
+      expect(result.model).to eq("gemini-2.5-flash-001")
+    end
 
     it "takes the last usageMetadata block across streamed chunks" do
       events = [


### PR DESCRIPTION
## Summary

Adds automatic cost capture for the [`gemini-ai`](https://github.com/gbaptista/gemini-ai) Ruby gem (v4.3+). Enable with `config.instrument :gemini_ai`.

- Patches `Gemini::Controllers::Client#request` to intercept blocking and SSE calls
- Captures `generate_content` (blocking + SSE) and `stream_generate_content`
- Budget enforcement runs on every call regardless of path or streaming mode
- `countTokens`, `embedContent`, and `predict` pass through unrecorded
- Gemini parser updated to prefer `modelVersion` from the response body over URL-derived model, so alias/latest calls record the actual resolved model

## Notes

- `gemini-ai` exposes `Gemini::GEM[:version]` instead of `Gemini::VERSION` — `constant_version` is overridden to handle this
- `enforce_budget!` is overridden to pass `provider: "gemini"` (not `"gemini_ai"`) so pricing lookups hit the registry correctly
- `:gemini_ai` added to `DOUBLE_INSTRUMENTATION_OVERLAPS` since `ruby_llm` can also route to Gemini

## Verification

```
bundle exec rspec spec/llm_cost_tracker/integrations/gemini_ai_spec.rb
bundle exec rspec spec/llm_cost_tracker/providers/gemini/parser_spec.rb
bundle exec rspec spec/llm_cost_tracker/integrations/install_contract_spec.rb
bundle exec rspec
bundle exec rubocop
```