### PR TITLE
feat(prices): add gemini-3.1-flash-image-preview pricing

### DIFF
--- a/lib/llm_cost_tracker/prices.json
+++ b/lib/llm_cost_tracker/prices.json
@@ -216,6 +216,21 @@
       "priority_input": 0.45,
       "priority_output": 2.7
     },
+    "gemini/gemini-2.5-flash-image": {
+      "audio_input": 1.0,
+      "batch_image_output": 15.0,
+      "batch_input": 0.15,
+      "cache_read_input": 0.03,
+      "image_output": 30.0,
+      "input": 0.3,
+      "output": 2.5
+    },
+    "gemini/gemini-3.1-flash-image-preview": {
+      "batch_image_output": 30.0,
+      "batch_input": 0.25,
+      "image_output": 60.0,
+      "input": 0.5
+    },
     "gemini/gemini-3.5-flash": {
       "batch_cache_read_input": 0.075,
       "batch_input": 0.75,


### PR DESCRIPTION
Adds pricing for two Gemini image generation models (Nano Banana family) that were missing from the bundled snapshot.

## gemini/gemini-2.5-flash-image

| Rate | Per 1M tokens |
|---|---|
| `input` | $0.30 |
| `output` (text) | $2.50 |
| `image_output` | $30.00 (~$0.039/image at 1,290 tokens) |
| `batch_input` | $0.15 |
| `batch_image_output` | $15.00 |
| `audio_input` | $1.00 |
| `cache_read_input` | $0.03 |

## gemini/gemini-3.1-flash-image-preview

| Rate | Per 1M tokens |
|---|---|
| `input` | $0.50 |
| `image_output` | $60.00 |
| `batch_input` | $0.25 |
| `batch_image_output` | $30.00 |

Source: https://ai.google.dev/gemini-api/docs/pricing