### PR TITLE
Fix engine not registering when gem is required (autoload → require)

### DIFF
--- a/lib/llm_cost_tracker.rb
+++ b/lib/llm_cost_tracker.rb
@@ -30,7 +30,7 @@ require_relative "llm_cost_tracker/ingestion"
 require_relative "llm_cost_tracker/tracker"
 
 module LlmCostTracker
-  autoload :Engine, "llm_cost_tracker/engine"
+  require_relative "llm_cost_tracker/engine"
   autoload :Doctor, "llm_cost_tracker/doctor"
   autoload :CaptureVerifier, "llm_cost_tracker/capture_verifier"
   autoload :Report, "llm_cost_tracker/report"


### PR DESCRIPTION
## What broke and why

When adding `llm_cost_tracker` to a Rails app, the dashboard at `/admin/llm_cost_tracker` returns a 404 — even with the migration run, the initializer configured, and the engine correctly mounted in `config/routes.rb`.

The root cause is in `lib/llm_cost_tracker.rb`:

```ruby
autoload :Engine, "llm_cost_tracker/engine"
```

`autoload` is lazy — the class is not defined until something first accesses the constant. The problem is timing. Rails boot follows this sequence:

1. `Bundler.require` runs → `llm_cost_tracker.rb` is loaded → `autoload` is registered, but `LlmCostTracker::Engine` **does not exist yet**
2. Rails collects `Rails::Engine.subclasses` and runs `add_routing_paths` initializers for each engine
3. Rails loads `config/routes.rb` → `mount LlmCostTracker::Engine` is evaluated → **autoload triggers here**, the class is defined now
4. Too late — `add_routing_paths` already finished without seeing this engine, so no routes are registered and no route file is added to the reloader

The engine is invisible to Rails. Every request to the dashboard returns 404.

This only affects `Engine` and not the other `autoload` declarations (`Doctor`, `CaptureVerifier`, etc.) because those are passive classes. `Engine`, on the other hand, inherits from `Rails::Engine`, which fires Ruby's `inherited` hook at class-definition time to register the subclass. That registration must happen before Rails boot initializers run — `autoload` breaks that assumption.

## The fix

Change `autoload` to `require_relative` for the engine:

```ruby
require_relative "llm_cost_tracker/engine"
```

This matches the convention used by every other Rails engine gem (Devise, Pay, Turbo, Sidekiq, etc.) and ensures the engine is registered before Rails collects its subclasses.

## How we discovered this

After installing the gem and mounting the engine, the dashboard returned 404. Inspecting `Rails::Engine.subclasses` at runtime showed `LlmCostTracker::Engine` was absent from the list entirely. Checking `Rails.application.routes_reloader.paths` confirmed the engine's `config/routes.rb` was never added to the reloader. The workaround — adding `require "llm_cost_tracker/engine"` to the app's `config/application.rb` after `Bundler.require` — confirmed the diagnosis and unblocked us, but the fix belongs in the gem.