### PR TITLE
Move Groq price scrape to the console models page

### DIFF
--- a/scripts/price_scrape/providers/groq.rb
+++ b/scripts/price_scrape/providers/groq.rb
@@ -9,10 +9,10 @@ module LlmCostTracker
   module Pricing::Scrape
     module Providers
       class Groq < Base
-        source_url "https://groq.com/pricing"
+        source_url "https://console.groq.com/docs/models"
         min_models 4
         max_price 1000.0
-        anchors "llama-3.1-8b-instant", "openai/gpt-oss-20b"
+        anchors "openai/gpt-oss-20b", "openai/gpt-oss-120b"
 
         PROMPT_CACHING_SOURCE_URL = "https://console.groq.com/docs/prompt-caching"
         FLEX_PROCESSING_SOURCE_URL = "https://console.groq.com/docs/flex-processing"
@@ -50,28 +50,10 @@ module LlmCostTracker
         end
 
         def extract_models(doc, cache_models:)
-          table = find_text_models_table(doc)
-          raise Error, "Groq token models pricing table not found" unless table
+          tables = find_text_models_tables(doc)
+          raise Error, "Groq token models pricing table not found" if tables.empty?
 
-          headers = header_texts(table)
-          model_index = column_index(headers, "AI MODEL")
-          input_index = column_index(headers, "INPUT TOKEN PRICE")
-          output_index = column_index(headers, "OUTPUT TOKEN PRICE")
-          last_index = [model_index, input_index, output_index].max
-
-          rows = table.css("tbody tr").filter_map do |row|
-            cells = row.css("td")
-            next if cells.size <= last_index
-
-            model_id = model_card_id(row)
-            next unless model_id
-
-            input = price_from_cell(cells[input_index])
-            output = price_from_cell(cells[output_index])
-            next unless input && output
-
-            { id: model_id, name: normalize_text(cells[model_index].text), input: input, output: output }
-          end
+          rows = tables.flat_map { |table| token_rows(table) }
 
           resolve_rows(rows).transform_values do |row|
             fields = add_mode_prices("input" => row[:input], "output" => row[:output])
@@ -79,12 +61,30 @@ module LlmCostTracker
           end
         end
 
-        def find_text_models_table(doc)
-          doc.css("table").find do |table|
+        def token_rows(table)
+          headers = header_texts(table)
+          model_index = column_index(headers, "MODEL ID")
+          price_index = column_index(headers, "PRICE PER")
+          last_index = [model_index, price_index].max
+
+          table.css("tbody tr").filter_map do |row|
+            cells = row.css("td")
+            next if cells.size <= last_index
+
+            model_id = model_card_id(row)
+            next unless model_id
+
+            input, output = token_prices(cells[price_index])
+            next unless input && output
+
+            { id: model_id, name: normalize_text(cells[model_index].text), input: input, output: output }
+          end
+        end
+
+        def find_text_models_tables(doc)
+          doc.css("table").select do |table|
             headers = header_texts(table)
-            header?(headers, "AI MODEL") &&
-              header?(headers, "INPUT TOKEN PRICE") &&
-              header?(headers, "OUTPUT TOKEN PRICE")
+            header?(headers, "MODEL ID") && header?(headers, "PRICE PER")
           end
         end
 
@@ -111,9 +111,13 @@ module LlmCostTracker
           id if model_id?(id)
         end
 
-        def price_from_cell(cell)
-          text = normalize_text(cell.text).gsub(/\([^)]*\)/, " ")
-          match = text.match(/\$\s*(\d+(?:\.\d+)?)/)
+        def token_prices(cell)
+          text = normalize_text(cell.text)
+          [labeled_price(text, "input"), labeled_price(text, "output")]
+        end
+
+        def labeled_price(text, label)
+          match = text.match(/\$\s*(\d+(?:\.\d+)?)\s*#{label}\b/i)
           return nil unless match
 
           Float(match[1])

--- a/spec/fixtures/scrape/groq_models.html
+++ b/spec/fixtures/scrape/groq_models.html
@@ -1,85 +1,295 @@
 <html>
   <body>
-    <h2>Token Pricing</h2>
+    <h1>Supported Models</h1>
+    <h2>Production Models</h2>
     <table>
-      <thead>
-        <tr>
-          <th>Model</th>
-          <th>Uncached Input Tokens (Per M Tokens)</th>
-          <th>Cached Input Tokens (Per M Tokens)</th>
-          <th>Output Tokens (Per M Tokens)</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>openai/gpt-oss-120b</td>
-          <td>$0.15</td>
-          <td>$0.075</td>
-          <td>$0.60</td>
-        </tr>
-      </tbody>
+    <thead><tr>
+    <th>MODEL ID</th>
+    <th>SPEED
+    (T/SEC)</th>
+    <th>PRICE PER
+    1M TOKENS</th>
+    <th>RATE LIMITS
+    (DEVELOPER PLAN)</th>
+    <th>CONTEXT WINDOW
+    (TOKENS)</th>
+    <th>MAX
+    COMPLETION TOKENS</th>
+    <th>MAX FILE
+    SIZE</th>
+    </tr></thead>
+    <tbody>
+    <tr>
+    <td><div><div><div>
+    <div><a href="/docs/model/llama-3.1-8b-instant">Llama 3.1 8B</a></div>
+    <span>llama-3.1-8b-instant</span>
+    </div></div></div></td>
+    <td><div><div>560</div></div></td>
+    <td><div><div><div>
+    <span>$0.05<!-- --> <span>input</span></span><span>$0.08<!-- --> <span>output</span></span>
+    </div></div></div></td>
+    <td><div><div><div>
+    <span>250K<!-- --> <span>TPM</span></span><span>1K<!-- --> <span>RPM</span></span>
+    </div></div></div></td>
+    <td><div><div>131,072</div></div></td>
+    <td><div><div>131,072</div></div></td>
+    <td><div><div>-</div></div></td>
+    </tr>
+    <tr>
+    <td><div><div><div>
+    <div><a href="/docs/model/llama-3.3-70b-versatile">Llama 3.3 70B</a></div>
+    <span>llama-3.3-70b-versatile</span>
+    </div></div></div></td>
+    <td><div><div>280</div></div></td>
+    <td><div><div><div>
+    <span>$0.59<!-- --> <span>input</span></span><span>$0.79<!-- --> <span>output</span></span>
+    </div></div></div></td>
+    <td><div><div><div>
+    <span>300K<!-- --> <span>TPM</span></span><span>1K<!-- --> <span>RPM</span></span>
+    </div></div></div></td>
+    <td><div><div>131,072</div></div></td>
+    <td><div><div>32,768</div></div></td>
+    <td><div><div>-</div></div></td>
+    </tr>
+    <tr>
+    <td><div><div><div>
+    <div><a href="/docs/model/openai/gpt-oss-120b">GPT OSS 120B</a></div>
+    <span>openai/gpt-oss-120b</span>
+    </div></div></div></td>
+    <td><div><div>500</div></div></td>
+    <td><div><div><div>
+    <span>$0.15<!-- --> <span>input</span></span><span>$0.60<!-- --> <span>output</span></span>
+    </div></div></div></td>
+    <td><div><div><div>
+    <span>250K<!-- --> <span>TPM</span></span><span>1K<!-- --> <span>RPM</span></span>
+    </div></div></div></td>
+    <td><div><div>131,072</div></div></td>
+    <td><div><div>65,536</div></div></td>
+    <td><div><div>-</div></div></td>
+    </tr>
+    <tr>
+    <td><div><div><div>
+    <div><a href="/docs/model/openai/gpt-oss-20b">GPT OSS 20B</a></div>
+    <span>openai/gpt-oss-20b</span>
+    </div></div></div></td>
+    <td><div><div>1000</div></div></td>
+    <td><div><div><div>
+    <span>$0.075<!-- --> <span>input</span></span><span>$0.30<!-- --> <span>output</span></span>
+    </div></div></div></td>
+    <td><div><div><div>
+    <span>250K<!-- --> <span>TPM</span></span><span>1K<!-- --> <span>RPM</span></span>
+    </div></div></div></td>
+    <td><div><div>131,072</div></div></td>
+    <td><div><div>65,536</div></div></td>
+    <td><div><div>-</div></div></td>
+    </tr>
+    <tr>
+    <td><div><div><div>
+    <div><a href="/docs/model/whisper-large-v3">Whisper</a></div>
+    <span>whisper-large-v3</span>
+    </div></div></div></td>
+    <td><div><div>-</div></div></td>
+    <td><div><div><div><span>$0.111<!-- --> <span>per hour</span></span></div></div></div></td>
+    <td><div><div><div>
+    <span>200K<!-- --> <span>ASH</span></span><span>300<!-- --> <span>RPM</span></span>
+    </div></div></div></td>
+    <td><div><div>-</div></div></td>
+    <td><div><div>-</div></div></td>
+    <td><div><div>100 MB</div></div></td>
+    </tr>
+    <tr>
+    <td><div><div><div>
+    <div><a href="/docs/model/whisper-large-v3-turbo">Whisper Large V3 Turbo</a></div>
+    <span>whisper-large-v3-turbo</span>
+    </div></div></div></td>
+    <td><div><div>-</div></div></td>
+    <td><div><div><div><span>$0.04<!-- --> <span>per hour</span></span></div></div></div></td>
+    <td><div><div><div>
+    <span>400K<!-- --> <span>ASH</span></span><span>400<!-- --> <span>RPM</span></span>
+    </div></div></div></td>
+    <td><div><div>-</div></div></td>
+    <td><div><div>-</div></div></td>
+    <td><div><div>-</div></div></td>
+    </tr>
+    </tbody>
     </table>
+    <h2>Production Systems</h2>
     <table>
-      <thead>
-        <tr>
-          <th>AI Model</th>
-          <th>Current Speed (Tokens per Second)</th>
-          <th>Input Token Price (Per Million Tokens)</th>
-          <th>Output Token Price (Per Million Tokens)</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>GPT OSS 20B 128k</td>
-          <td>1,000 TPS</td>
-          <td>Input Token Price (Per Million Tokens) $0.075 (13.3M / $1)*</td>
-          <td>Output Token Price (Per Million Tokens) $0.30 (3.33M / $1)*</td>
-          <td>
-            <a href="https://console.groq.com/playground?model=openai/gpt-oss-120b">Try Now</a>
-            <a href="https://console.groq.com/docs/model/openai/gpt-oss-20b">Model Card</a>
-          </td>
-        </tr>
-        <tr>
-          <td>GPT OSS Safeguard 20B</td>
-          <td>1,000 TPS</td>
-          <td>Input Token Price (Per Million Tokens) $0.075 (13.3M / $1)*</td>
-          <td>Output Token Price (Per Million Tokens) $0.30 (3.33M / $1)*</td>
-          <td>
-            <a href="https://console.groq.com/playground?model=openai/gpt-oss-120b">Try Now</a>
-            <a href="https://console.groq.com/docs/model/openai/gpt-oss-120b">Model Card</a>
-          </td>
-        </tr>
-        <tr>
-          <td>GPT OSS 120B 128k</td>
-          <td>500 TPS</td>
-          <td>Input Token Price (Per Million Tokens) $0.15 (6.67M / $1)*</td>
-          <td>Output Token Price (Per Million Tokens) $0.60 (1.66M / $1)*</td>
-          <td>
-            <a href="https://console.groq.com/playground?model=openai/gpt-oss-120b">Try Now</a>
-            <a href="https://console.groq.com/docs/model/openai/gpt-oss-120b">Model Card</a>
-          </td>
-        </tr>
-        <tr>
-          <td>Llama 3.3 70B Versatile 128k</td>
-          <td>280 TPS</td>
-          <td>Input Token Price (Per Million Tokens) $0.59</td>
-          <td>Output Token Price (Per Million Tokens) $0.79</td>
-          <td>
-            <a href="https://console.groq.com/playground?model=llama-3.3-70b-versatile">Try Now</a>
-            <a href="https://console.groq.com/docs/model/llama-3.3-70b-versatile">Model Card</a>
-          </td>
-        </tr>
-        <tr>
-          <td>Llama 3.1 8B Instant 128k</td>
-          <td>560 TPS</td>
-          <td>Input Token Price (Per Million Tokens) $0.05</td>
-          <td>Output Token Price (Per Million Tokens) $0.08</td>
-          <td>
-            <a href="https://console.groq.com/playground?model=llama-3.1-8b-instant">Try Now</a>
-            <a href="https://console.groq.com/docs/model/llama-3.1-8b-instant">Model Card</a>
-          </td>
-        </tr>
-      </tbody>
+    <thead><tr>
+    <th>MODEL ID</th>
+    <th>SPEED
+    (T/SEC)</th>
+    <th>PRICE PER
+    1M TOKENS</th>
+    <th>RATE LIMITS
+    (DEVELOPER PLAN)</th>
+    <th>CONTEXT WINDOW
+    (TOKENS)</th>
+    <th>MAX
+    COMPLETION TOKENS</th>
+    <th>MAX FILE
+    SIZE</th>
+    </tr></thead>
+    <tbody>
+    <tr>
+    <td><div><div><div>
+    <div><a href="/docs/compound/systems/compound">Compound</a></div>
+    <span>groq/compound</span>
+    </div></div></div></td>
+    <td><div><div>450</div></div></td>
+    <td><div><div>-</div></div></td>
+    <td><div><div><div>
+    <span>200K<!-- --> <span>TPM</span></span><span>200<!-- --> <span>RPM</span></span>
+    </div></div></div></td>
+    <td><div><div>131,072</div></div></td>
+    <td><div><div>8,192</div></div></td>
+    <td><div><div>-</div></div></td>
+    </tr>
+    <tr>
+    <td><div><div><div>
+    <div><a href="/docs/compound/systems/compound-mini">Compound Mini</a></div>
+    <span>groq/compound-mini</span>
+    </div></div></div></td>
+    <td><div><div>450</div></div></td>
+    <td><div><div>-</div></div></td>
+    <td><div><div><div>
+    <span>200K<!-- --> <span>TPM</span></span><span>200<!-- --> <span>RPM</span></span>
+    </div></div></div></td>
+    <td><div><div>131,072</div></div></td>
+    <td><div><div>8,192</div></div></td>
+    <td><div><div>-</div></div></td>
+    </tr>
+    </tbody>
+    </table>
+    <h2>Preview Models</h2>
+    <table>
+    <thead><tr>
+    <th>MODEL ID</th>
+    <th>SPEED
+    (T/SEC)</th>
+    <th>PRICE PER
+    1M TOKENS</th>
+    <th>RATE LIMITS
+    (DEVELOPER PLAN)</th>
+    <th>CONTEXT WINDOW
+    (TOKENS)</th>
+    <th>MAX
+    COMPLETION TOKENS</th>
+    <th>MAX FILE
+    SIZE</th>
+    </tr></thead>
+    <tbody>
+    <tr>
+    <td><div><div><div>
+    <div><a href="/docs/model/canopylabs/orpheus-arabic-saudi">Canopy Labs Orpheus Arabic Saudi</a></div>
+    <span>canopylabs/orpheus-arabic-saudi</span>
+    </div></div></div></td>
+    <td><div><div>-</div></div></td>
+    <td><div><div><div><span>$40.00<!-- --> <span>per 1M characters</span></span></div></div></div></td>
+    <td><div><div><div>
+    <span>50K<!-- --> <span>TPM</span></span><span>250<!-- --> <span>RPM</span></span>
+    </div></div></div></td>
+    <td><div><div>4,000</div></div></td>
+    <td><div><div>50,000</div></div></td>
+    <td><div><div>-</div></div></td>
+    </tr>
+    <tr>
+    <td><div><div><div>
+    <div><a href="/docs/model/canopylabs/orpheus-v1-english">Canopy Labs Orpheus V1 English</a></div>
+    <span>canopylabs/orpheus-v1-english</span>
+    </div></div></div></td>
+    <td><div><div>-</div></div></td>
+    <td><div><div><div><span>$22.00<!-- --> <span>per 1M characters</span></span></div></div></div></td>
+    <td><div><div><div>
+    <span>50K<!-- --> <span>TPM</span></span><span>250<!-- --> <span>RPM</span></span>
+    </div></div></div></td>
+    <td><div><div>4,000</div></div></td>
+    <td><div><div>50,000</div></div></td>
+    <td><div><div>-</div></div></td>
+    </tr>
+    <tr>
+    <td><div><div><div>
+    <div><a href="/docs/model/meta-llama/llama-prompt-guard-2-22m">Llama Prompt Guard 2 22M</a></div>
+    <span>meta-llama/llama-prompt-guard-2-22m</span>
+    </div></div></div></td>
+    <td><div><div>-</div></div></td>
+    <td><div><div><div>
+    <span>$0.03<!-- --> <span>input</span></span><span>$0.03<!-- --> <span>output</span></span>
+    </div></div></div></td>
+    <td><div><div><div>
+    <span>30K<!-- --> <span>TPM</span></span><span>100<!-- --> <span>RPM</span></span>
+    </div></div></div></td>
+    <td><div><div>512</div></div></td>
+    <td><div><div>512</div></div></td>
+    <td><div><div>-</div></div></td>
+    </tr>
+    <tr>
+    <td><div><div><div>
+    <div><a href="/docs/model/meta-llama/llama-prompt-guard-2-86m">Prompt Guard 2 86M</a></div>
+    <span>meta-llama/llama-prompt-guard-2-86m</span>
+    </div></div></div></td>
+    <td><div><div>-</div></div></td>
+    <td><div><div><div>
+    <span>$0.04<!-- --> <span>input</span></span><span>$0.04<!-- --> <span>output</span></span>
+    </div></div></div></td>
+    <td><div><div><div>
+    <span>30K<!-- --> <span>TPM</span></span><span>100<!-- --> <span>RPM</span></span>
+    </div></div></div></td>
+    <td><div><div>512</div></div></td>
+    <td><div><div>512</div></div></td>
+    <td><div><div>-</div></div></td>
+    </tr>
+    <tr>
+    <td><div><div><div>
+    <div>
+    <a href="/docs/model/minimaxai/minimax-m2.7">MiniMax M2.7</a><span>Enterprise</span>
+    </div>
+    <span>minimaxai/minimax-m2.7</span>
+    </div></div></div></td>
+    <td><div><div>260</div></div></td>
+    <td><div><div><div>
+    <span>Contact</span><span>Sales</span>
+    </div></div></div></td>
+    <td><div><div><div>
+    <span>Contact</span><span>Sales</span>
+    </div></div></div></td>
+    <td><div><div>196,608</div></div></td>
+    <td><div><div>131,072</div></div></td>
+    <td><div><div>-</div></div></td>
+    </tr>
+    <tr>
+    <td><div><div><div>
+    <div><a href="/docs/model/openai/gpt-oss-safeguard-20b">Safety GPT OSS 20B</a></div>
+    <span>openai/gpt-oss-safeguard-20b</span>
+    </div></div></div></td>
+    <td><div><div>1000</div></div></td>
+    <td><div><div><div>
+    <span>$0.075<!-- --> <span>input</span></span><span>$0.30<!-- --> <span>output</span></span>
+    </div></div></div></td>
+    <td><div><div><div>
+    <span>150K<!-- --> <span>TPM</span></span><span>1K<!-- --> <span>RPM</span></span>
+    </div></div></div></td>
+    <td><div><div>131,072</div></div></td>
+    <td><div><div>65,536</div></div></td>
+    <td><div><div>-</div></div></td>
+    </tr>
+    <tr>
+    <td><div><div><div>
+    <div><a href="/docs/model/qwen/qwen3.6-27b">Qwen/Qwen3.6-27B</a></div>
+    <span>qwen/qwen3.6-27b</span>
+    </div></div></div></td>
+    <td><div><div>500</div></div></td>
+    <td><div><div><div>
+    <span>$0.60<!-- --> <span>input</span></span><span>$3.00<!-- --> <span>output</span></span>
+    </div></div></div></td>
+    <td><div><div><div>
+    <span>250K<!-- --> <span>TPM</span></span><span>1K<!-- --> <span>RPM</span></span>
+    </div></div></div></td>
+    <td><div><div>131,072</div></div></td>
+    <td><div><div>16,384</div></div></td>
+    <td><div><div>20 MB</div></div></td>
+    </tr>
+    </tbody>
     </table>
   </body>
 </html>

--- a/spec/llm_cost_tracker/pricing_spec.rb
+++ b/spec/llm_cost_tracker/pricing_spec.rb
@@ -1068,7 +1068,7 @@ RSpec.describe LlmCostTracker::Pricing do
     end
 
     it "keeps output more expensive than input for chat-style models" do
-      non_chat = /embed|audio|whisper|tts|image|moderation/
+      non_chat = /embed|audio|whisper|tts|image|moderation|guard/
       bundled.each do |model_id, fields|
         next if model_id.start_with?("openrouter/")
         next if model_id.match?(non_chat)

--- a/spec/scripts/price_scrape/providers/groq_spec.rb
+++ b/spec/scripts/price_scrape/providers/groq_spec.rb
@@ -19,13 +19,16 @@ RSpec.describe LlmCostTracker::Pricing::Scrape::Providers::Groq do
   def text_models_table(rows)
     body = rows.map do |row|
       card = row[:card] || row[:id]
+      price = row.fetch(:price) do
+        "<span>$#{row[:input]}<!-- --> <span>input</span></span>" \
+          "<span>$#{row[:output]}<!-- --> <span>output</span></span>"
+      end
       <<~ROW
         <tr>
-          <td>#{row[:name]}</td>
-          <td>500 TPS</td>
-          <td>Input Token Price (Per Million Tokens) $#{row[:input]} (per $1)*</td>
-          <td>Output Token Price (Per Million Tokens) $#{row[:output]} (per $1)*</td>
-          <td><a href="https://console.groq.com/docs/model/#{card}">Model Card</a></td>
+          <td><a href="/docs/model/#{card}">#{row[:name]}</a><span>#{row[:id]}</span></td>
+          <td>500</td>
+          <td>#{price}</td>
+          <td>250K<!-- --> TPM</td>
         </tr>
       ROW
     end.join
@@ -34,10 +37,10 @@ RSpec.describe LlmCostTracker::Pricing::Scrape::Providers::Groq do
       <table>
         <thead>
           <tr>
-            <th>AI Model</th>
-            <th>Current Speed (Tokens per Second)</th>
-            <th>Input Token Price (Per Million Tokens)</th>
-            <th>Output Token Price (Per Million Tokens)</th>
+            <th>MODEL ID</th>
+            <th>SPEED (T/SEC)</th>
+            <th>PRICE PER 1M TOKENS</th>
+            <th>RATE LIMITS (DEVELOPER PLAN)</th>
           </tr>
         </thead>
         <tbody>#{body}</tbody>
@@ -46,22 +49,22 @@ RSpec.describe LlmCostTracker::Pricing::Scrape::Providers::Groq do
   end
 
   def models_page(table)
-    "<html><body><h2>Pricing</h2>#{table}</body></html>"
+    "<html><body><h1>Supported Models</h1>#{table}</body></html>"
   end
 
   describe "#call" do
-    it "extracts token model prices from the pricing page and derives Groq mode rates" do
+    it "extracts token model prices from the models page and derives Groq mode rates" do
       result = described_class.new.call(html: html_pages, scraped_at: "2026-05-01T00:00:00Z")
 
       expect(result.source_url).to eq(described_class.source_url)
       expect(result.scraped_at).to eq("2026-05-01T00:00:00Z")
-      expect(result.models.fetch("llama-3.1-8b-instant")).to eq(
-        "input" => 0.05,
-        "output" => 0.08,
-        "on_demand_input" => 0.05,
-        "on_demand_output" => 0.08,
-        "flex_input" => 0.05,
-        "flex_output" => 0.08
+      expect(result.models.fetch("qwen/qwen3.6-27b")).to eq(
+        "input" => 0.6,
+        "output" => 3.0,
+        "on_demand_input" => 0.6,
+        "on_demand_output" => 3.0,
+        "flex_input" => 0.6,
+        "flex_output" => 3.0
       )
       expect(result.models.fetch("openai/gpt-oss-20b")).to eq(
         "input" => 0.075,
@@ -76,14 +79,54 @@ RSpec.describe LlmCostTracker::Pricing::Scrape::Providers::Groq do
       )
     end
 
-    it "reads the model id from the Model Card link rather than the display name" do
+    it "reads the model id from the model card link rather than the display name" do
       result = described_class.new.call(html: html_pages)
 
       expect(result.models.keys).to include("llama-3.3-70b-versatile", "openai/gpt-oss-120b")
     end
 
-    it "drops a row whose Model Card link collides with another model and keeps the consistent one" do
+    it "merges token models from the production and preview tables" do
       result = described_class.new.call(html: html_pages)
+
+      expect(result.models.keys).to include("llama-3.1-8b-instant", "qwen/qwen3.6-27b")
+    end
+
+    it "skips rows priced per hour, per character, or on request" do
+      result = described_class.new.call(html: html_pages)
+
+      expect(result.models.keys).not_to include(
+        "whisper-large-v3",
+        "canopylabs/orpheus-v1-english",
+        "minimaxai/minimax-m2.7"
+      )
+    end
+
+    it "skips rows that link to a system rather than a model card" do
+      result = described_class.new.call(html: html_pages)
+
+      expect(result.models.keys).not_to include("groq/compound", "groq/compound-mini")
+    end
+
+    it "drops a row whose model card link collides with another model and keeps the consistent one" do
+      page = models_page(
+        text_models_table(
+          [
+            { name: "GPT OSS 120B", id: "openai/gpt-oss-120b", input: "0.15", output: "0.60" },
+            {
+              name: "Safety GPT OSS 20B",
+              id: "openai/gpt-oss-safeguard-20b",
+              card: "openai/gpt-oss-120b",
+              input: "0.075",
+              output: "0.30"
+            },
+            { name: "Llama 3.1 8B", id: "llama-3.1-8b-instant", input: "0.05", output: "0.08" },
+            { name: "Llama 3.3 70B", id: "llama-3.3-70b-versatile", input: "0.59", output: "0.79" },
+            { name: "GPT OSS 20B", id: "openai/gpt-oss-20b", input: "0.075", output: "0.30" }
+          ]
+        )
+      )
+
+      result = described_class.new.call(html: html_pages(described_class.source_url => page))
 
       expect(result.models.fetch("openai/gpt-oss-120b")).to include("input" => 0.15, "output" => 0.6)
       expect(result.models.size).to eq(4)
@@ -94,8 +137,8 @@ RSpec.describe LlmCostTracker::Pricing::Scrape::Providers::Groq do
               "<tbody><tr><td>Web Search</td><td>$5 / 1000 requests</td></tr></tbody></table>"
       text_table = text_models_table(
         [
-          { name: "Llama 3.1 8B Instant", id: "llama-3.1-8b-instant", input: "0.05", output: "0.08" },
-          { name: "Llama 3.3 70B Versatile", id: "llama-3.3-70b-versatile", input: "0.59", output: "0.79" },
+          { name: "Llama 3.1 8B", id: "llama-3.1-8b-instant", input: "0.05", output: "0.08" },
+          { name: "Llama 3.3 70B", id: "llama-3.3-70b-versatile", input: "0.59", output: "0.79" },
           { name: "GPT OSS 20B", id: "openai/gpt-oss-20b", input: "0.075", output: "0.30" },
           { name: "GPT OSS 120B", id: "openai/gpt-oss-120b", input: "0.15", output: "0.60" }
         ]
@@ -126,9 +169,9 @@ RSpec.describe LlmCostTracker::Pricing::Scrape::Providers::Groq do
       page = models_page(
         text_models_table(
           [
-            { name: "Alpha One", id: "openai/gpt-oss-120b", input: "0.15", output: "0.60" },
-            { name: "Beta Two", id: "openai/gpt-oss-120b", input: "0.30", output: "0.60" },
-            { name: "Llama 3.1 8B Instant", id: "llama-3.1-8b-instant", input: "0.05", output: "0.08" }
+            { name: "Alpha One", id: "alpha-one", card: "openai/gpt-oss-120b", input: "0.15", output: "0.60" },
+            { name: "Beta Two", id: "beta-two", card: "openai/gpt-oss-120b", input: "0.30", output: "0.60" },
+            { name: "Llama 3.1 8B", id: "llama-3.1-8b-instant", input: "0.05", output: "0.08" }
           ]
         )
       )
@@ -163,23 +206,23 @@ RSpec.describe LlmCostTracker::Pricing::Scrape::Providers::Groq do
       end.to raise_error(described_class::Error, /flex on-demand pricing/)
     end
 
-    it "skips a row whose token price cannot be parsed" do
+    it "skips a row whose price cell labels only one side of the token price" do
       page = models_page(
         text_models_table(
           [
-            { name: "Llama 3.1 8B Instant", id: "llama-3.1-8b-instant", input: "0.05", output: "0.08" },
-            { name: "Llama 3.3 70B Versatile", id: "llama-3.3-70b-versatile", input: "0.59", output: "0.79" },
+            { name: "Llama 3.1 8B", id: "llama-3.1-8b-instant", input: "0.05", output: "0.08" },
+            { name: "Llama 3.3 70B", id: "llama-3.3-70b-versatile", price: "<span>$0.59<!-- --> <span>input</span>" },
             { name: "GPT OSS 20B", id: "openai/gpt-oss-20b", input: "0.075", output: "0.30" },
             { name: "GPT OSS 120B", id: "openai/gpt-oss-120b", input: "0.15", output: "0.60" },
-            { name: "Qwen3 32B", id: "qwen/qwen3-32b", input: "0.29", output: "0.59" }
+            { name: "Qwen3.6 27B", id: "qwen/qwen3.6-27b", input: "0.60", output: "3.00" }
           ]
-        ).sub("Input Token Price (Per Million Tokens) $0.59", "Input Token Price (Per Million Tokens) TBD")
+        )
       )
 
       result = described_class.new.call(html: html_pages(described_class.source_url => page))
 
       expect(result.models).not_to include("llama-3.3-70b-versatile")
-      expect(result.models.keys).to include("qwen/qwen3-32b", "openai/gpt-oss-20b")
+      expect(result.models.keys).to include("qwen/qwen3.6-27b", "openai/gpt-oss-20b")
     end
   end
 end


### PR DESCRIPTION
`https://groq.com/pricing` now redirects to the groq.com homepage, which is client-side rendered and carries no pricing tables, so the daily refresh failed with "token models pricing table not found". `/docs/pricing` and `console.groq.com/pricing` both 404 — `console.groq.com/docs/models` is the only surviving server-rendered Groq pricing surface.

The parser matches `MODEL ID` + `PRICE PER`, reads input and output from the single labelled price cell, and merges every header-matching table so preview models are covered. Rows priced per hour, per character, or on request drop out on their own. Anchors moved to the two GPT-OSS models: `llama-3.1-8b-instant` has a published shutdown date of 08/16/26 and would have broken the scrape again within days.

The `output > input` invariant now skips classifier models — Groq prices `llama-prompt-guard-2-22m` at `$0.03 input / $0.03 output`, which would have turned CI red on the first refresh that wrote it.

Verified with `bin/check` and `PROVIDERS=groq DRY_RUN=1 bundle exec ruby scripts/price_scrape/runner.rb`: 8 models parsed, `added=3 removed=0 updated=0` — the five existing prices are byte-identical, confirming the new source carries the same data.

Closes #91
