### PR TITLE
Prune Groq models past their published shutdown date

### DIFF
--- a/scripts/price_scrape/providers/groq.rb
+++ b/scripts/price_scrape/providers/groq.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "date"
 require "nokogiri"
 require "time"
 
@@ -16,15 +17,23 @@ module LlmCostTracker
 
         PROMPT_CACHING_SOURCE_URL = "https://console.groq.com/docs/prompt-caching"
         FLEX_PROCESSING_SOURCE_URL = "https://console.groq.com/docs/flex-processing"
-        SOURCE_URLS = [source_url, PROMPT_CACHING_SOURCE_URL, FLEX_PROCESSING_SOURCE_URL].freeze
+        DEPRECATIONS_SOURCE_URL = "https://console.groq.com/docs/deprecations"
+        SOURCE_URLS = [
+          source_url,
+          PROMPT_CACHING_SOURCE_URL,
+          FLEX_PROCESSING_SOURCE_URL,
+          DEPRECATIONS_SOURCE_URL
+        ].freeze
 
         MODEL_CARD_PATH = "/docs/model/"
+        SHUTDOWN_DATE_FORMAT = "%m/%d/%y"
 
         def call(html:, source_url: self.class.source_url, scraped_at: Time.now.utc.iso8601)
           pages = pages_from(html)
           pricing_doc = Nokogiri::HTML(pages.fetch(self.class.source_url))
           prompt_caching_doc = Nokogiri::HTML(pages.fetch(PROMPT_CACHING_SOURCE_URL))
           flex_doc = Nokogiri::HTML(pages.fetch(FLEX_PROCESSING_SOURCE_URL))
+          deprecations_doc = Nokogiri::HTML(pages.fetch(DEPRECATIONS_SOURCE_URL))
 
           verify_prompt_cache_discount!(prompt_caching_doc)
           verify_flex_pricing!(flex_doc)
@@ -36,7 +45,7 @@ module LlmCostTracker
             source_url: source_url,
             scraped_at: scraped_at,
             models: models,
-            deprecated_models: [],
+            deprecated_models: extract_shutdown_models(deprecations_doc, scraped_at: scraped_at),
             service_charges: {}
           )
         end
@@ -96,8 +105,11 @@ module LlmCostTracker
           headers.any? { |header| header.upcase.include?(needle) }
         end
 
-        def column_index(headers, needle)
-          index = headers.find_index { |header| header.upcase.include?(needle) }
+        def column_index(headers, needle, excluding: nil)
+          index = headers.find_index do |header|
+            upcased = header.upcase
+            upcased.include?(needle) && !(excluding && upcased.include?(excluding))
+          end
           raise Error, "Groq pricing column #{needle.inspect} not found in #{headers.inspect}" unless index
 
           index
@@ -180,6 +192,38 @@ module LlmCostTracker
           raise Error, "expected at least 2 prompt caching models, parsed #{models.size}" if models.size < 2
 
           models
+        end
+
+        def extract_shutdown_models(doc, scraped_at:)
+          tables = doc.css("table").select { |table| header?(header_texts(table), "SHUTDOWN DATE") }
+          raise Error, "Groq deprecations table not found" if tables.empty?
+
+          scraped_on = Date.parse(scraped_at)
+          tables.flat_map { |table| shutdown_rows(table, scraped_on: scraped_on) }.uniq
+        end
+
+        def shutdown_rows(table, scraped_on:)
+          headers = header_texts(table)
+          model_index = column_index(headers, "MODEL", excluding: "REPLACEMENT")
+          shutdown_index = column_index(headers, "SHUTDOWN DATE")
+          last_index = [model_index, shutdown_index].max
+
+          table.css("tbody tr").filter_map do |row|
+            cells = row.css("td")
+            next if cells.size <= last_index
+
+            model_id = normalize_text(cells[model_index].text)
+            next unless model_id?(model_id)
+
+            shutdown_on = shutdown_date(cells[shutdown_index])
+            model_id if shutdown_on && shutdown_on <= scraped_on
+          end
+        end
+
+        def shutdown_date(cell)
+          Date.strptime(normalize_text(cell.text), SHUTDOWN_DATE_FORMAT)
+        rescue Date::Error
+          nil
         end
 
         def verify_prompt_cache_discount!(doc)

--- a/spec/fixtures/scrape/groq_deprecations.html
+++ b/spec/fixtures/scrape/groq_deprecations.html
@@ -1,0 +1,550 @@
+<html>
+  <body>
+    <h1>Deprecations</h1>
+    <table>
+    <thead><tr>
+    <th>Deprecated Model</th>
+    <th>Shutdown Date</th>
+    <th>Recommended Replacement Model ID</th>
+    </tr></thead>
+    <tbody>
+    <tr>
+    <td><div>
+    <code>llama-3.1-8b-instant</code><div></div>
+    </div></td>
+    <td>08/16/26</td>
+    <td><div>
+    <code>openai/gpt-oss-20b</code><div></div>
+    </div></td>
+    </tr>
+    <tr>
+    <td><div>
+    <code>llama-3.3-70b-versatile</code><div></div>
+    </div></td>
+    <td>08/16/26</td>
+    <td>
+    <div>
+    <code>openai/gpt-oss-120b</code><div></div>
+    </div> or <div>
+    <code>qwen/qwen3.6-27b</code><div></div>
+    </div>
+    </td>
+    </tr>
+    </tbody>
+    </table>
+    <table>
+    <thead><tr>
+    <th>Deprecated Model</th>
+    <th>Shutdown Date</th>
+    <th>Recommended Replacement Model ID</th>
+    </tr></thead>
+    <tbody>
+    <tr>
+    <td><div>
+    <code>qwen/qwen3-32b</code><div></div>
+    </div></td>
+    <td>07/17/26</td>
+    <td><div>
+    <code>openai/gpt-oss-120b</code><div></div>
+    </div></td>
+    </tr>
+    <tr>
+    <td><div>
+    <code>meta-llama/llama-4-scout-17b-16e-instruct</code><div></div>
+    </div></td>
+    <td>07/17/26</td>
+    <td>
+    <div>
+    <code>openai/gpt-oss-120b</code><div></div>
+    </div> or <div>
+    <code>qwen/qwen3.6-27b</code><div></div>
+    </div>
+    </td>
+    </tr>
+    </tbody>
+    </table>
+    <table>
+    <thead><tr>
+    <th>Deprecated Model</th>
+    <th>Shutdown Date</th>
+    <th>Recommended Replacement Model ID</th>
+    </tr></thead>
+    <tbody><tr>
+    <td><div>
+    <code>moonshotai/kimi-k2-instruct-0905</code><div></div>
+    </div></td>
+    <td>04/15/26</td>
+    <td><div>
+    <code>openai/gpt-oss-120b</code><div></div>
+    </div></td>
+    </tr></tbody>
+    </table>
+    <table>
+    <thead><tr>
+    <th>Deprecated Model</th>
+    <th>Shutdown Date</th>
+    <th>Recommended Replacement Model ID</th>
+    </tr></thead>
+    <tbody><tr>
+    <td><div>
+    <code>meta-llama/llama-4-maverick-17b-128e-instruct</code><div></div>
+    </div></td>
+    <td>03/09/26</td>
+    <td><div>
+    <code>openai/gpt-oss-120b</code><div></div>
+    </div></td>
+    </tr></tbody>
+    </table>
+    <table>
+    <thead><tr>
+    <th>Deprecated Model</th>
+    <th>Shutdown Date</th>
+    <th>Recommended Replacement Model ID</th>
+    </tr></thead>
+    <tbody><tr>
+    <td><div>
+    <code>meta-llama/llama-guard-4-12b</code><div></div>
+    </div></td>
+    <td>03/05/26</td>
+    <td><div>
+    <code>openai/gpt-oss-safeguard-20b</code><div></div>
+    </div></td>
+    </tr></tbody>
+    </table>
+    <table>
+    <thead><tr>
+    <th>Deprecated Model</th>
+    <th>Shutdown Date</th>
+    <th>Recommended Replacement Model ID</th>
+    </tr></thead>
+    <tbody>
+    <tr>
+    <td><div>
+    <code>playai-tts</code><div></div>
+    </div></td>
+    <td>12/31/25</td>
+    <td><div>
+    <code>canopylabs/orpheus-v1-english</code><div></div>
+    </div></td>
+    </tr>
+    <tr>
+    <td><div>
+    <code>playai-tts-arabic</code><div></div>
+    </div></td>
+    <td>12/31/25</td>
+    <td><div>
+    <code>canopylabs/orpheus-arabic-saudi</code><div></div>
+    </div></td>
+    </tr>
+    </tbody>
+    </table>
+    <table>
+    <thead><tr>
+    <th>Deprecated Model</th>
+    <th>Shutdown Date</th>
+    <th>Recommended Replacement Model ID</th>
+    </tr></thead>
+    <tbody><tr>
+    <td><div>
+    <code>moonshotai/kimi-k2-instruct</code><div></div>
+    </div></td>
+    <td>10/10/25</td>
+    <td><div>
+    <code>openai/gpt-oss-120b</code><div></div>
+    </div></td>
+    </tr></tbody>
+    </table>
+    <table>
+    <thead><tr>
+    <th>Deprecated Model</th>
+    <th>Shutdown Date</th>
+    <th>Recommended Replacement Model ID</th>
+    </tr></thead>
+    <tbody><tr>
+    <td><div>
+    <code>gemma2-9b-it</code><div></div>
+    </div></td>
+    <td>10/08/25</td>
+    <td><div>
+    <code>llama-3.1-8b-instant</code><div></div>
+    </div></td>
+    </tr></tbody>
+    </table>
+    <table>
+    <thead><tr>
+    <th>Deprecated Model</th>
+    <th>Shutdown Date</th>
+    <th>Recommended Replacement Model ID</th>
+    </tr></thead>
+    <tbody><tr>
+    <td><div>
+    <code>deepseek-r1-distill-llama-70b</code><div></div>
+    </div></td>
+    <td>10/02/25</td>
+    <td>
+    <div>
+    <code>llama-3.3-70b-versatile</code><div></div>
+    </div> or <div>
+    <code>openai/gpt-oss-120b</code><div></div>
+    </div>
+    </td>
+    </tr></tbody>
+    </table>
+    <table>
+    <thead><tr>
+    <th>Deprecated Model</th>
+    <th>Shutdown Date</th>
+    <th>Recommended Replacement Model ID</th>
+    </tr></thead>
+    <tbody>
+    <tr>
+    <td><div>
+    <code>llama3-70b-8192</code><div></div>
+    </div></td>
+    <td>08/30/25</td>
+    <td><div>
+    <code>llama-3.3-70b-versatile</code><div></div>
+    </div></td>
+    </tr>
+    <tr>
+    <td><div>
+    <code>llama3-8b-8192</code><div></div>
+    </div></td>
+    <td>08/30/25</td>
+    <td><div>
+    <code>llama-3.1-8b-instant</code><div></div>
+    </div></td>
+    </tr>
+    </tbody>
+    </table>
+    <table>
+    <thead><tr>
+    <th>Deprecated Model</th>
+    <th>Shutdown Date</th>
+    <th>Recommended Replacement Model ID</th>
+    </tr></thead>
+    <tbody><tr>
+    <td><div>
+    <code>distil-whisper-large-v3-en</code><div></div>
+    </div></td>
+    <td>08/23/25</td>
+    <td><div>
+    <code>whisper-large-v3-turbo</code><div></div>
+    </div></td>
+    </tr></tbody>
+    </table>
+    <table>
+    <thead><tr>
+    <th>Deprecated Model</th>
+    <th>Shutdown Date</th>
+    <th>Recommended Replacement Model ID</th>
+    </tr></thead>
+    <tbody><tr>
+    <td><div>
+    <code>mistral-saba-24b</code><div></div>
+    </div></td>
+    <td>07/30/25</td>
+    <td><div>
+    <code>qwen/qwen3-32b</code><div></div>
+    </div></td>
+    </tr></tbody>
+    </table>
+    <table>
+    <thead><tr>
+    <th>Deprecated Model</th>
+    <th>Shutdown Date</th>
+    <th>Recommended Replacement Model ID</th>
+    </tr></thead>
+    <tbody><tr>
+    <td><div>
+    <code>qwen-qwq-32b</code><div></div>
+    </div></td>
+    <td>07/14/25</td>
+    <td><div>
+    <code>qwen/qwen3-32b</code><div></div>
+    </div></td>
+    </tr></tbody>
+    </table>
+    <table>
+    <thead><tr>
+    <th>Deprecated Model</th>
+    <th>Shutdown Date</th>
+    <th>Recommended Replacement Model ID</th>
+    </tr></thead>
+    <tbody><tr>
+    <td><div>
+    <code>llama-guard-3-8b</code><div></div>
+    </div></td>
+    <td>06/06/25</td>
+    <td><div>
+    <code>meta-llama/llama-guard-4-12b</code><div></div>
+    </div></td>
+    </tr></tbody>
+    </table>
+    <table>
+    <thead><tr>
+    <th>Deprecated Model</th>
+    <th>Shutdown Date</th>
+    <th>Recommended Replacement Model ID</th>
+    </tr></thead>
+    <tbody>
+    <tr>
+    <td><div>
+    <code>llama-3.2-1b-preview</code><div></div>
+    </div></td>
+    <td>04/14/25</td>
+    <td><div>
+    <code>llama-3.1-8b-instant</code><div></div>
+    </div></td>
+    </tr>
+    <tr>
+    <td><div>
+    <code>llama-3.2-3b-preview</code><div></div>
+    </div></td>
+    <td>04/14/25</td>
+    <td><div>
+    <code>llama-3.1-8b-instant</code><div></div>
+    </div></td>
+    </tr>
+    <tr>
+    <td><div>
+    <code>llama-3.2-11b-vision-preview</code><div></div>
+    </div></td>
+    <td>04/14/25</td>
+    <td><div>
+    <code>meta-llama/llama-4-scout-17b-16e-instruct</code><div></div>
+    </div></td>
+    </tr>
+    <tr>
+    <td><div>
+    <code>llama-3.2-90b-vision-preview</code><div></div>
+    </div></td>
+    <td>04/14/25</td>
+    <td><div>
+    <code>meta-llama/llama-4-scout-17b-16e-instruct</code><div></div>
+    </div></td>
+    </tr>
+    <tr>
+    <td><div>
+    <code>deepseek-r1-distill-qwen-32b</code><div></div>
+    </div></td>
+    <td>04/14/25</td>
+    <td><div>
+    <code>qwen-qwq-32b</code><div></div>
+    </div></td>
+    </tr>
+    <tr>
+    <td><div>
+    <code>qwen-2.5-32b</code><div></div>
+    </div></td>
+    <td>04/14/25</td>
+    <td>
+    <div>
+    <code>qwen-qwq-32b</code><div></div>
+    </div>        <div>
+    <code>meta-llama/llama-4-scout-17b-16e-instruct</code><div></div>
+    </div>
+    </td>
+    </tr>
+    <tr>
+    <td><div>
+    <code>qwen-2.5-coder-32b</code><div></div>
+    </div></td>
+    <td>04/14/25</td>
+    <td>
+    <div>
+    <code>qwen-qwq-32b</code><div></div>
+    </div>        <div>
+    <code>openai/gpt-oss-120b</code><div></div>
+    </div>
+    </td>
+    </tr>
+    <tr>
+    <td><div>
+    <code>llama-3.3-70b-specdec</code><div></div>
+    </div></td>
+    <td>04/14/25</td>
+    <td>
+    <div>
+    <code>meta-llama/llama-4-scout-17b-16e-instruct</code><div></div>
+    </div>        <div>
+    <code>llama-3.3-70b-versatile</code><div></div>
+    </div>
+    </td>
+    </tr>
+    <tr>
+    <td><div>
+    <code>deepseek-r1-distill-llama-70b-specdec</code><div></div>
+    </div></td>
+    <td>04/14/25</td>
+    <td>
+    <div>
+    <code>deepseek-r1-distill-llama-70b</code><div></div>
+    </div>        <div>
+    <code>deepseek-r1-distill-qwen-32b</code><div></div>
+    </div>
+    </td>
+    </tr>
+    </tbody>
+    </table>
+    <table>
+    <thead><tr>
+    <th>Model ID</th>
+    <th>Shutdown Date</th>
+    <th>Recommended Replacement Model ID</th>
+    </tr></thead>
+    <tbody><tr>
+    <td><div>
+    <code>deepseek-r1-distill-llama-70b-specdec</code><div></div>
+    </div></td>
+    <td>03/24/25</td>
+    <td>
+    <div>
+    <code>deepseek-r1-distill-llama-70b</code><div></div>
+    </div>        <div>
+    <code>deepseek-r1-distill-qwen-32b</code><div></div>
+    </div>
+    </td>
+    </tr></tbody>
+    </table>
+    <table>
+    <thead><tr>
+    <th>Model ID</th>
+    <th>Shutdown Date</th>
+    <th>Recommended Replacement Model ID</th>
+    </tr></thead>
+    <tbody><tr>
+    <td><div>
+    <code>mixtral-8x7b-32768</code><div></div>
+    </div></td>
+    <td>03/20/25</td>
+    <td>
+    <div>
+    <code>mistral-saba-24b</code><div></div>
+    </div>        <div>
+    <code>llama-3.3-70b-versatile</code><div></div>
+    </div>
+    </td>
+    </tr></tbody>
+    </table>
+    <table>
+    <thead><tr>
+    <th>Model ID</th>
+    <th>Shutdown Date</th>
+    <th>Recommended Replacement Model ID</th>
+    </tr></thead>
+    <tbody>
+    <tr>
+    <td><div>
+    <code>llama-3.1-70b-versatile</code><div></div>
+    </div></td>
+    <td>01/24/25</td>
+    <td><div>
+    <code>llama-3.3-70b-versatile</code><div></div>
+    </div></td>
+    </tr>
+    <tr>
+    <td><div>
+    <code>llama-3.1-70b-specdec</code><div></div>
+    </div></td>
+    <td>01/24/25</td>
+    <td><div>
+    <code>llama-3.3-70b-specdec</code><div></div>
+    </div></td>
+    </tr>
+    </tbody>
+    </table>
+    <table>
+    <thead><tr>
+    <th>Model ID</th>
+    <th>Shutdown Date</th>
+    <th>Recommended Replacement Model ID</th>
+    </tr></thead>
+    <tbody>
+    <tr>
+    <td><div>
+    <code>llama3-groq-8b-8192-tool-use-preview</code><div></div>
+    </div></td>
+    <td>1/6/25</td>
+    <td><div>
+    <code>llama-3.3-70b-versatile</code><div></div>
+    </div></td>
+    </tr>
+    <tr>
+    <td><div>
+    <code>llama3-groq-70b-8192-tool-use-preview</code><div></div>
+    </div></td>
+    <td>1/6/25</td>
+    <td><div>
+    <code>llama-3.3-70b-versatile</code><div></div>
+    </div></td>
+    </tr>
+    </tbody>
+    </table>
+    <table>
+    <thead><tr>
+    <th>Model ID</th>
+    <th>Shutdown Date</th>
+    <th>Recommended Replacement Model ID</th>
+    </tr></thead>
+    <tbody><tr>
+    <td><div>
+    <code>gemma-7b-it</code><div></div>
+    </div></td>
+    <td>12/18/24</td>
+    <td><div>
+    <code>gemma2-9b-it</code><div></div>
+    </div></td>
+    </tr></tbody>
+    </table>
+    <table>
+    <thead><tr>
+    <th>Model ID</th>
+    <th>Shutdown Date</th>
+    <th>Recommended Replacement Model ID</th>
+    </tr></thead>
+    <tbody><tr>
+    <td><div>
+    <code>llama-3.2-90b-text-preview</code><div></div>
+    </div></td>
+    <td>11/25/24</td>
+    <td>
+    <div>
+    <code>llama-3.2-90b-vision-preview</code><div></div>
+    </div>        <div>
+    <code>llama-3.1-70b-versatile</code><div></div>
+    </div> (text-only workloads)</td>
+    </tr></tbody>
+    </table>
+    <table>
+    <thead><tr>
+    <th>Model ID</th>
+    <th>Shutdown Date</th>
+    <th>Recommended Replacement Model ID</th>
+    </tr></thead>
+    <tbody>
+    <tr>
+    <td><div>
+    <code>llava-v1.5-7b-4096-preview</code><div></div>
+    </div></td>
+    <td>10/28/24</td>
+    <td><div>
+    <code>llama-3.2-11b-vision-preview</code><div></div>
+    </div></td>
+    </tr>
+    <tr>
+    <td><div>
+    <code>llama-3.2-11b-text-preview</code><div></div>
+    </div></td>
+    <td>10/28/24</td>
+    <td>
+    <div>
+    <code>llama-3.2-11b-vision-preview</code><div></div>
+    </div>        <div>
+    <code>llama-3.1-8b-instant</code><div></div>
+    </div> (text-only workloads)</td>
+    </tr>
+    </tbody>
+    </table>
+  </body>
+</html>

--- a/spec/llm_cost_tracker/pricing_spec.rb
+++ b/spec/llm_cost_tracker/pricing_spec.rb
@@ -164,15 +164,15 @@ RSpec.describe LlmCostTracker::Pricing do
     it "calculates Groq flex costs at on-demand token rates" do
       result = cost_for(
         provider: "groq",
-        model: "llama-3.3-70b-versatile",
+        model: "openai/gpt-oss-120b",
         pricing_mode: "flex",
         input_tokens: 1_000_000,
         output_tokens: 1_000_000
       )
 
-      expect(result.components.fetch(:input_cost)).to eq(0.59)
-      expect(result.components.fetch(:output_cost)).to eq(0.79)
-      expect(result.total).to eq(1.38)
+      expect(result.components.fetch(:input_cost)).to eq(0.15)
+      expect(result.components.fetch(:output_cost)).to eq(0.6)
+      expect(result.total).to eq(0.75)
     end
 
     it "keeps Groq provisioned performance pricing unknown" do

--- a/spec/scripts/price_scrape/providers/groq_spec.rb
+++ b/spec/scripts/price_scrape/providers/groq_spec.rb
@@ -7,12 +7,14 @@ RSpec.describe LlmCostTracker::Pricing::Scrape::Providers::Groq do
   let(:models_html) { File.read("spec/fixtures/scrape/groq_models.html", encoding: "utf-8") }
   let(:prompt_caching_html) { File.read("spec/fixtures/scrape/groq_prompt_caching.html", encoding: "utf-8") }
   let(:flex_processing_html) { File.read("spec/fixtures/scrape/groq_flex_processing.html", encoding: "utf-8") }
+  let(:deprecations_html) { File.read("spec/fixtures/scrape/groq_deprecations.html", encoding: "utf-8") }
 
   def html_pages(overrides = {})
     {
       described_class.source_url => models_html,
       described_class::PROMPT_CACHING_SOURCE_URL => prompt_caching_html,
-      described_class::FLEX_PROCESSING_SOURCE_URL => flex_processing_html
+      described_class::FLEX_PROCESSING_SOURCE_URL => flex_processing_html,
+      described_class::DEPRECATIONS_SOURCE_URL => deprecations_html
     }.merge(overrides)
   end
 
@@ -154,9 +156,70 @@ RSpec.describe LlmCostTracker::Pricing::Scrape::Providers::Groq do
       expect(result.models.size).to be >= described_class.min_models
     end
 
-    it "sets deprecated_models to empty" do
-      result = described_class.new.call(html: html_pages)
-      expect(result.deprecated_models).to eq([])
+    it "reports models whose shutdown date has already passed as deprecated" do
+      result = described_class.new.call(html: html_pages, scraped_at: "2026-08-08T00:00:00Z")
+
+      expect(result.deprecated_models).to include(
+        "qwen/qwen3-32b",
+        "meta-llama/llama-4-scout-17b-16e-instruct"
+      )
+    end
+
+    it "keeps a model priced until its announced shutdown date arrives" do
+      before_shutdown = described_class.new.call(html: html_pages, scraped_at: "2026-08-15T00:00:00Z")
+      on_shutdown = described_class.new.call(html: html_pages, scraped_at: "2026-08-16T00:00:00Z")
+
+      expect(before_shutdown.deprecated_models).not_to include("llama-3.1-8b-instant")
+      expect(on_shutdown.deprecated_models).to include("llama-3.1-8b-instant")
+    end
+
+    it "lists a model deprecated in more than one table only once" do
+      result = described_class.new.call(html: html_pages, scraped_at: "2026-08-08T00:00:00Z")
+
+      expect(result.deprecated_models.count("deepseek-r1-distill-llama-70b-specdec")).to eq(1)
+    end
+
+    it "reads the deprecated model column rather than the recommended replacement column" do
+      reordered = <<~HTML
+        <html><body><table>
+          <thead>
+            <tr>
+              <th>Recommended Replacement Model ID</th>
+              <th>Shutdown Date</th>
+              <th>Deprecated Model</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td>openai/gpt-oss-120b</td><td>01/01/26</td><td>llama3-8b-8192</td></tr>
+          </tbody>
+        </table></body></html>
+      HTML
+
+      result = described_class.new.call(
+        html: html_pages(described_class::DEPRECATIONS_SOURCE_URL => reordered),
+        scraped_at: "2026-08-08T00:00:00Z"
+      )
+
+      expect(result.deprecated_models).to eq(["llama3-8b-8192"])
+    end
+
+    it "raises when the deprecations table is missing" do
+      expect do
+        described_class.new.call(
+          html: html_pages(described_class::DEPRECATIONS_SOURCE_URL => "<html><body></body></html>")
+        )
+      end.to raise_error(described_class::Error, /deprecations table not found/)
+    end
+
+    it "keeps a model priced when its shutdown date cannot be read" do
+      unreadable = deprecations_html.sub("<td>07/17/26</td>", "<td>TBD</td>")
+
+      result = described_class.new.call(
+        html: html_pages(described_class::DEPRECATIONS_SOURCE_URL => unreadable),
+        scraped_at: "2026-08-08T00:00:00Z"
+      )
+
+      expect(result.deprecated_models).not_to include("qwen/qwen3-32b")
     end
 
     it "raises when the token model table is missing" do

--- a/spec/scripts/price_scrape/runner_spec.rb
+++ b/spec/scripts/price_scrape/runner_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe LlmCostTracker::Pricing::Scrape::Runner do
   let(:groq_models_html) { File.read("spec/fixtures/scrape/groq_models.html", encoding: "utf-8") }
   let(:groq_prompt_caching_html) { File.read("spec/fixtures/scrape/groq_prompt_caching.html", encoding: "utf-8") }
   let(:groq_flex_processing_html) { File.read("spec/fixtures/scrape/groq_flex_processing.html", encoding: "utf-8") }
+  let(:groq_deprecations_html) { File.read("spec/fixtures/scrape/groq_deprecations.html", encoding: "utf-8") }
 
   def build_registry(haiku_entry:)
     {
@@ -73,6 +74,9 @@ RSpec.describe LlmCostTracker::Pricing::Scrape::Runner do
     stub_request(:get, LlmCostTracker::Pricing::Scrape::Providers::Groq::FLEX_PROCESSING_SOURCE_URL)
       .to_return(status: 200, body: groq_flex_processing_html,
                  headers: { "Content-Type" => "text/html; charset=utf-8" })
+    stub_request(:get, LlmCostTracker::Pricing::Scrape::Providers::Groq::DEPRECATIONS_SOURCE_URL)
+      .to_return(status: 200, body: groq_deprecations_html,
+                 headers: { "Content-Type" => "text/html; charset=utf-8" })
 
     Tempfile.create(["registry", ".json"]) do |file|
       file.write(JSON.pretty_generate("metadata" => { "schema_version" => 1, "updated_at" => "2026-04-01" },
@@ -89,6 +93,9 @@ RSpec.describe LlmCostTracker::Pricing::Scrape::Runner do
       )
       expect(io.string).to include(
         "[groq] fetching #{LlmCostTracker::Pricing::Scrape::Providers::Groq::FLEX_PROCESSING_SOURCE_URL}"
+      )
+      expect(io.string).to include(
+        "[groq] fetching #{LlmCostTracker::Pricing::Scrape::Providers::Groq::DEPRECATIONS_SOURCE_URL}"
       )
     end
   end


### PR DESCRIPTION
Groq publishes a shutdown date for every retired model, but the parser hardcoded `deprecated_models: []`, so retired entries keep frozen prices in `prices.json` forever — `qwen/qwen3-32b` and `meta-llama/llama-4-scout-17b-16e-instruct` were retired on 07/17/26 and are still priced today.

The parser now reads `console.groq.com/docs/deprecations` and reports a model only once its shutdown date has passed, so a model announced for retirement keeps its price until it actually goes away. The orchestrator already turns `deprecated_models` into registry removals.

The model column is matched excluding `REPLACEMENT`, so a column reorder cannot make the parser read the recommended-replacement ids and delete live models instead.

Verified with `bin/check` and `PROVIDERS=groq DRY_RUN=1 bundle exec ruby scripts/price_scrape/runner.rb`: `parsed 8 models (deprecated: 34)`, `added=3 removed=2` — exactly the two stale entries. Boundary checked on both sides: at 2026-08-15 `llama-3.1-8b-instant` is still priced, at 2026-08-16 it is pruned.

Stacked on #92.
