### PR TITLE
Log the final URL when a price source redirects

### DIFF
--- a/scripts/price_scrape/runner.rb
+++ b/scripts/price_scrape/runner.rb
@@ -82,6 +82,7 @@ module LlmCostTracker
         source_urls(provider_class).each_with_object({}) do |url, responses|
           @io.puts "[#{name}] fetching #{url}"
           response = @fetcher.get(url)
+          @io.puts "[#{name}] redirected to #{response.url}" if response.url != url
           @io.puts "[#{name}] HTTP #{response.status} (#{response.body.bytesize} bytes, #{response.elapsed_ms}ms)"
           responses[url] = response
         end

--- a/spec/scripts/price_scrape/runner_spec.rb
+++ b/spec/scripts/price_scrape/runner_spec.rb
@@ -93,6 +93,33 @@ RSpec.describe LlmCostTracker::Pricing::Scrape::Runner do
     end
   end
 
+  it "logs the final URL when a source page redirects elsewhere" do
+    stub_request(:get, LlmCostTracker::Pricing::Scrape::Providers::Anthropic.source_url)
+      .to_return(status: 301, headers: { "Location" => "https://example.test/moved" })
+    stub_request(:get, "https://example.test/moved")
+      .to_return(status: 200, body: html, headers: { "Content-Type" => "text/html; charset=utf-8" })
+
+    Tempfile.create(["registry", ".json"]) do |file|
+      file.write(JSON.pretty_generate(build_registry(haiku_entry: { "input" => 1.0, "output" => 5.0 })))
+      file.close
+
+      described_class.new(io: io).call(providers: ["anthropic"], registry_path: file.path, dry_run: true)
+
+      expect(io.string).to include("[anthropic] redirected to https://example.test/moved")
+    end
+  end
+
+  it "stays quiet about redirects when a source page answers directly" do
+    Tempfile.create(["registry", ".json"]) do |file|
+      file.write(JSON.pretty_generate(build_registry(haiku_entry: { "input" => 1.0, "output" => 5.0 })))
+      file.close
+
+      described_class.new(io: io).call(providers: ["anthropic"], registry_path: file.path, dry_run: true)
+
+      expect(io.string).not_to include("redirected to")
+    end
+  end
+
   it "raises on an unknown provider name" do
     expect do
       described_class.new(io: io).call(providers: ["xai"])


### PR DESCRIPTION
When a provider's source URL starts redirecting, the fetcher follows it and the runner logs `HTTP 200` against the requested URL, so a page that moved reads as a parser bug. That is how #91 presented for three days: `groq.com/pricing` was redirecting to the marketing homepage while the log blamed a missing table.

`Response#url` already carries the final URL — the runner now prints it when it differs from the one requested.
