### PR TITLE
Hold the openai dev dependency below 0.78

### DIFF
--- a/llm_cost_tracker.gemspec
+++ b/llm_cost_tracker.gemspec
@@ -51,7 +51,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "anthropic", "~> 1.42"
   spec.add_development_dependency "nokogiri", "~> 1.16"
-  spec.add_development_dependency "openai", "~> 0.63"
+  spec.add_development_dependency "openai", "~> 0.63", "< 0.78"
   spec.add_development_dependency "pg", "~> 1.6"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
`openai` 0.78.0 was released on 2026-08-08 and breaks every spec that stubs a multipart upload — audio transcriptions, audio translations, `images.edit`, `images.create_variation`, and the streaming variants — 7 failures across the whole Rails matrix. The dev dependency was `~> 0.63`, so CI resolved 0.78.0 the moment it shipped. `main` itself is red for this reason, independent of any open PR.

The bug is in the SDK's `ReadIOAdapter::InterruptibleEnumerator#to_a`:

```ruby
def to_a
  values = []
  loop { values << self.next }
rescue StopIteration
  values
end
```

`Kernel#loop` already swallows `StopIteration`, so the `rescue` never runs and the method returns `loop`'s value — `StopIteration#result`, which is `nil` for a bare `raise StopIteration`. The trailing `values` is missing. WebMock reads the request body with `read(nil)` to build its request signature, that reaches `@stream.to_a.join`, and it blows up with `undefined method 'join' for nil`.

Only the read-everything path is affected; chunked reads take the `Integer` branch and never call `to_a`.

Holding the dev dependency at `< 0.78` resolves 0.77.1 and turns the suite green again. Development-only, so nothing changes for gem consumers. Worth lifting once upstream ships the missing `values`.
