### PR TITLE
Fix: backfill_unknown_pricing crashes when rollup caching is disabled

### DIFF
--- a/lib/llm_cost_tracker/pricing/backfill.rb
+++ b/lib/llm_cost_tracker/pricing/backfill.rb
@@ -30,7 +30,9 @@ module LlmCostTracker
                 rollup_events << rollup_event_for(call, calculation)
                 recomputed += 1
               end
-              Ledger::Rollups.increment!(rollup_events) if rollup_events.any?
+              if LlmCostTracker.configuration.cache_rollups && rollup_events.any?
+                Ledger::Rollups.increment!(rollup_events)
+              end
             end
           end
 

--- a/spec/llm_cost_tracker/pricing/backfill_spec.rb
+++ b/spec/llm_cost_tracker/pricing/backfill_spec.rb
@@ -122,4 +122,30 @@ RSpec.describe LlmCostTracker::Pricing::Backfill do
                                 .sum(:total_cost)
     }.from(0).to(be > 0)
   end
+
+  it "does not touch rollups when cache_rollups is disabled and the rollups table is absent" do
+    LlmCostTracker.configuration.cache_rollups = false
+    ActiveRecord::Base.connection.drop_table(:llm_cost_tracker_call_rollups, if_exists: true)
+
+    call = create_call(
+      provider: "openai",
+      model: "gpt-4o",
+      input_tokens: 1_000,
+      output_tokens: 500,
+      total_cost: nil,
+      pricing_snapshot: nil,
+      cost_status: "unknown"
+    )
+    add_line_items(
+      call,
+      [
+        { direction: "input", quantity: 1_000, price_key: "input" },
+        { direction: "output", quantity: 500, price_key: "output" }
+      ]
+    )
+
+    result = nil
+    expect { result = described_class.call }.not_to raise_error
+    expect(result.recomputed).to eq(1) # proves the call was still repriced, not just silently skipped
+  end
 end


### PR DESCRIPTION
Started using this gem more and more, and found an issue with the backfilling of unknown pricing when you don't enable (and create the tables) rollup cache config.

`LlmCostTracker::Pricing::Backfill.call` (from the `llm_cost_tracker:backfill_unknown_pricing` rake task) unconditionally calls `Ledger::Rollups.increment!`, which upserts the `llm_cost_tracker_call_rollups` table. This table is optionally created through a separate rake task.

An exception is raised due to a missing index when upserting on the non existing table:

```
ArgumentError
No unique index found for [:period, :period_start, :currency, :provider] (ArgumentError)

          raise ArgumentError, "No unique index found for #{name_or_columns}"
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

It looks like we are already guarding against this in other places where the gem writes rollups, so I'm guessing it's just a missed leftover that is kind of forgotten about once the rollups table is created.